### PR TITLE
Add basic n8n workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,18 @@ SPRING_DATASOURCE_PASSWORD=postgres
 AIRTABLE_API_KEY=your_airtable_key
 AIRTABLE_BASE_ID=your_base_id
 
+# Airtable table where transactions will be stored
+AIRTABLE_TABLE_NAME=Movimientos
+
 # N8N
 N8N_BASIC_AUTH_USER=admin
 N8N_BASIC_AUTH_PASSWORD=password
+
+# Email accounts
+SANTANDER_IMAP_HOST=imap.santander.com
+SANTANDER_IMAP_USER=notificaciones@santander.com
+SANTANDER_IMAP_PASSWORD=password
+
+PREX_IMAP_HOST=imap.prex.com
+PREX_IMAP_USER=notificaciones@prex.com
+PREX_IMAP_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ Accede a:
 ## 🔐 Variables de entorno
 
 Copiar y configurar `.env` desde `.env.example`.
+
+## 🚀 Flujo de unificación de movimientos
+
+Se provee un workflow de n8n en `n8n/workflows/email-to-airtable.json`.
+Este flujo se conecta por IMAP a las cuentas de notificaciones de
+Santander y Prex, normaliza la información de cada correo y la
+guarda en una tabla de Airtable.
+
+Pasos para probar el MVP:
+
+1. Completar las credenciales de IMAP y Airtable en `.env`.
+2. Ejecutar `scripts/setup.sh` para levantar los servicios con Docker.
+3. Importar el workflow en la instancia de n8n (`http://localhost:5678`).

--- a/n8n/email-to-airtable.json
+++ b/n8n/email-to-airtable.json
@@ -1,0 +1,73 @@
+{
+  "name": "Unificar movimientos",
+  "nodes": [
+    {
+      "parameters": {
+        "protocol": "IMAP",
+        "host": "{{ $env.SANTANDER_IMAP_HOST }}",
+        "user": "{{ $env.SANTANDER_IMAP_USER }}",
+        "password": "{{ $env.SANTANDER_IMAP_PASSWORD }}",
+        "mailbox": "INBOX",
+        "downloadAttachments": false
+      },
+      "name": "Leer emails Santander",
+      "type": "n8n-nodes-base.emailReadImap",
+      "typeVersion": 1,
+      "position": [300, 300]
+    },
+    {
+      "parameters": {
+        "protocol": "IMAP",
+        "host": "{{ $env.PREX_IMAP_HOST }}",
+        "user": "{{ $env.PREX_IMAP_USER }}",
+        "password": "{{ $env.PREX_IMAP_PASSWORD }}",
+        "mailbox": "INBOX",
+        "downloadAttachments": false
+      },
+      "name": "Leer emails Prex",
+      "type": "n8n-nodes-base.emailReadImap",
+      "typeVersion": 1,
+      "position": [300, 600]
+    },
+    {
+      "parameters": {
+        "functionCode": "const data = items.map(item => {\n  const subject = item.json.subject || '';\n  const amountMatch = subject.match(/(-?\d+[.,]\d+)/);\n  const amount = amountMatch ? amountMatch[1].replace(',', '.') : null;\n  return {\n    date: item.json.date,\n    description: subject,\n    amount,\n    source: item.node.name.includes('Santander') ? 'Santander' : 'Prex'\n  };\n});\nreturn data.map(d => ({ json: d }));"
+      },
+      "name": "Normalizar",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [600, 450]
+    },
+    {
+      "parameters": {
+        "operation": "create",
+        "baseId": "{{ $env.AIRTABLE_BASE_ID }}",
+        "tableId": "{{ $env.AIRTABLE_TABLE_NAME }}",
+        "fieldsUi": {
+          "field": [
+            { "fieldId": "Fecha", "fieldValue": "={{$json[\"date\"]}}" },
+            { "fieldId": "Descripcion", "fieldValue": "={{$json[\"description\"]}}" },
+            { "fieldId": "Monto", "fieldValue": "={{$json[\"amount\"]}}" },
+            { "fieldId": "Origen", "fieldValue": "={{$json[\"source\"]}}" }
+          ]
+        }
+      },
+      "name": "Guardar en Airtable",
+      "type": "n8n-nodes-base.airtable",
+      "typeVersion": 2,
+      "position": [900, 450]
+    }
+  ],
+  "connections": {
+    "Leer emails Santander": {
+      "main": [ [ { "node": "Normalizar", "type": "main", "index": 0 } ] ]
+    },
+    "Leer emails Prex": {
+      "main": [ [ { "node": "Normalizar", "type": "main", "index": 0 } ] ]
+    },
+    "Normalizar": {
+      "main": [ [ { "node": "Guardar en Airtable", "type": "main", "index": 0 } ] ]
+    }
+  },
+  "active": false
+}


### PR DESCRIPTION
## Summary
- provide `.env.example` variables for IMAP credentials
- document how to run the MVP and import the workflow
- add a starter n8n workflow that reads emails from Santander and Prex
  and stores normalized transactions in Airtable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684825cfe21883298d8bfa7785b09e93