### PR TITLE
Fix Dockerfile build context paths

### DIFF
--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY ../backend .
+COPY . .
 RUN ./gradlew build -x test
 CMD ["java", "-jar", "build/libs/app.jar"]

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-alpine AS build
 WORKDIR /app
-COPY ../frontend .
+COPY . .
 RUN npm install && npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
## Summary
- fix backend and frontend Dockerfiles so `docker build` uses correct context

## Testing
- `bash scripts/setup.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848273ac98083299f6cd3985bb5124e